### PR TITLE
Create consumer per partition

### DIFF
--- a/examples/simple-json/docker-compose.yaml
+++ b/examples/simple-json/docker-compose.yaml
@@ -24,6 +24,7 @@ services:
       - KAFKA_CFG_LISTENERS=CLIENT://:9092,EXTERNAL://:19092
       - KAFKA_CFG_ADVERTISED_LISTENERS=CLIENT://kafka:9092,EXTERNAL://localhost:19092
       - KAFKA_INTER_BROKER_LISTENER_NAME=CLIENT
+      - KAFKA_AUTO_CREATE_TOPICS_ENABLE=false
     depends_on:
       - zookeeper
     healthcheck:

--- a/examples/simple-json/publisher/publish_messages.sh
+++ b/examples/simple-json/publisher/publish_messages.sh
@@ -1,6 +1,4 @@
 echo 'Create topic'
-kafka-topics.sh --bootstrap-server kafka:9092 \
-  --delete --topic super-heros
 kafka-topics.sh --bootstrap-server kafka:9092 --partitions 4 --replication-factor 1 \
   --create --topic super-heros
 echo 'Create Kafka Messages'

--- a/examples/simple-json/publisher/publish_messages.sh
+++ b/examples/simple-json/publisher/publish_messages.sh
@@ -1,3 +1,8 @@
+echo 'Create topic'
+kafka-topics.sh --bootstrap-server kafka:9092 \
+  --delete --topic super-heros
+kafka-topics.sh --bootstrap-server kafka:9092 --partitions 4 --replication-factor 1 \
+  --create --topic super-heros
 echo 'Create Kafka Messages'
 counter=0
 while true

--- a/http/src/main/kotlin/kafkasnoop/KafkaClientFactory.kt
+++ b/http/src/main/kotlin/kafkasnoop/KafkaClientFactory.kt
@@ -1,10 +1,20 @@
 package kafkasnoop
 
+import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.slf4j.LoggerFactory
 import java.util.Properties
+import java.util.UUID
 
 class KafkaClientFactory(private val props: Properties) {
+    companion object {
+        private val logger = LoggerFactory.getLogger(KafkaClientFactory::class.java)
+    }
+
     fun createConsumer(): KafkaConsumer<ByteArray, ByteArray> {
+        val consumerId = "kafkasnoop-consumer-${UUID.randomUUID()}"
+        logger.info("Create consumer $consumerId")
+        props.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, consumerId)
         return KafkaConsumer<ByteArray, ByteArray>(props)
     }
 }

--- a/http/src/main/kotlin/kafkasnoop/Server.kt
+++ b/http/src/main/kotlin/kafkasnoop/Server.kt
@@ -3,6 +3,7 @@ package kafkasnoop
 import io.ktor.application.*
 import io.ktor.features.*
 import io.ktor.gson.*
+import io.ktor.http.cio.websocket.*
 import io.ktor.routing.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
@@ -10,6 +11,7 @@ import io.ktor.websocket.*
 import kafkasnoop.routes.messages
 import kafkasnoop.routes.topics
 import org.slf4j.LoggerFactory
+import java.time.Duration
 
 class Server(private val kafkaClientFactory: KafkaClientFactory) {
     companion object {

--- a/http/src/main/kotlin/kafkasnoop/StartSnoop.kt
+++ b/http/src/main/kotlin/kafkasnoop/StartSnoop.kt
@@ -31,7 +31,6 @@ class StartSnoop : CliktCommand() {
                 ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG to ByteArrayDeserializer::class.java.name,
                 ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG to ByteArrayDeserializer::class.java.name,
                 ConsumerConfig.MAX_POLL_RECORDS_CONFIG to "100",
-                ConsumerConfig.CLIENT_ID_CONFIG to "kafkasnoop-consumer",
                 ConsumerConfig.ISOLATION_LEVEL_CONFIG to "read_committed"
             ) + kafkaCliOptions
             ).toProperties()

--- a/http/src/main/kotlin/kafkasnoop/dto/Message.kt
+++ b/http/src/main/kotlin/kafkasnoop/dto/Message.kt
@@ -1,7 +1,15 @@
 package kafkasnoop.dto
 
-data class Message(val offset: Long, val partition: String, val key: String, val value: String) {
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+
+internal var formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME.withZone(ZoneId.from(ZoneOffset.UTC))
+
+data class Message(val offset: Long, val partition: String, val key: String, val value: String, val timestamp: Long) {
     override fun toString(): String {
-        return "$offset|$partition|$key|$value"
+        return "$offset|$partition|$key|$value|${formatter.format(Instant.ofEpochSecond(timestamp))}"
     }
 }

--- a/http/src/main/kotlin/kafkasnoop/dto/Message.kt
+++ b/http/src/main/kotlin/kafkasnoop/dto/Message.kt
@@ -1,7 +1,7 @@
 package kafkasnoop.dto
 
-data class Message(val partition: String, val key: String, val value: String) {
+data class Message(val offset: Long, val partition: String, val key: String, val value: String) {
     override fun toString(): String {
-        return "$partition|$key|$value"
+        return "$offset|$partition|$key|$value"
     }
 }

--- a/http/src/main/kotlin/kafkasnoop/dto/Message.kt
+++ b/http/src/main/kotlin/kafkasnoop/dto/Message.kt
@@ -5,11 +5,10 @@ import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 
-
 internal var formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME.withZone(ZoneId.from(ZoneOffset.UTC))
 
 data class Message(val offset: Long, val partition: String, val key: String, val value: String, val timestamp: Long) {
     override fun toString(): String {
-        return "$offset|$partition|$key|$value|${formatter.format(Instant.ofEpochSecond(timestamp))}"
+        return "$offset|$partition|$key|$value|${formatter.format(Instant.ofEpochMilli(timestamp))}"
     }
 }

--- a/http/src/main/kotlin/kafkasnoop/dto/Topic.kt
+++ b/http/src/main/kotlin/kafkasnoop/dto/Topic.kt
@@ -1,4 +1,10 @@
 package kafkasnoop.dto
 
-data class Partition(val index: Int, val inSyncReplicas: Int, val offlineReplicas: Int)
+data class Partition(
+    val index: Int,
+    val beginOffset: Long,
+    val endOffset: Long,
+    val inSyncReplicas: Int,
+    val offlineReplicas: Int,
+)
 data class Topic(val name: String, val partitions: List<Partition>)

--- a/http/src/main/kotlin/kafkasnoop/routes/MessageProcessor.kt
+++ b/http/src/main/kotlin/kafkasnoop/routes/MessageProcessor.kt
@@ -1,16 +1,16 @@
 package kafkasnoop.routes
 
 import kafkasnoop.dto.Message
-import kotlinx.coroutines.yield
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.common.TopicPartition
 import java.time.Duration
+import kotlin.math.max
 
 class MessageProcessor(
     private val kafkaConsumer: KafkaConsumer<ByteArray, ByteArray>,
     private val topicName: String,
     // todo: take offset from query string & filter partitions
-    private val startOffset: Long = 0L,
+    private val startOffset: Long? = null,
 ) {
     private val partitions: List<TopicPartition>
     init {
@@ -20,30 +20,54 @@ class MessageProcessor(
             TopicPartition(it.topic(), it.partition())
         }
         kafkaConsumer.assign(partitions)
-        val beggingOffsets = kafkaConsumer.beginningOffsets(partitions)
-
-        partitions.forEach { p ->
-            val pOffset = java.lang.Long.max(beggingOffsets[p] ?: 0, startOffset)
-            logger.info("Begging offset for partition $p is $pOffset")
-            kafkaConsumer.seek(p, pOffset)
-        }
     }
 
     fun startProcess(maxMsgCount: Int = Int.MAX_VALUE) =
         sequence {
+            val beggingOffsets = kafkaConsumer.beginningOffsets(partitions)
+            val endOffsets = kafkaConsumer.endOffsets(partitions)
+
+            if (logger.isDebugEnabled) {
+                beggingOffsets.forEach {
+                    logger.debug("Begin Offset for ${it.key} is ${it.value}")
+                }
+                endOffsets.forEach {
+                    logger.debug("End Offset for ${it.key} is ${it.value}")
+                }
+            }
+
+            // default to rewinding to 100 or max msg count
+            val offsetDiff = if (maxMsgCount == Int.MAX_VALUE) 100 else maxMsgCount
+            val startOffset = max(endOffsets.maxOf { it.value }.minus(offsetDiff), 0)
+
+            logger.info("Return messasges from offset $startOffset")
+
+            partitions.forEach { p ->
+                logger.debug("Min offset for partition $p is ${beggingOffsets[p]}")
+                logger.debug("Max offset for partition $p is ${endOffsets[p]}")
+                val offset = max(startOffset, beggingOffsets[p] ?: 0)
+                logger.info("Start at offset for partition $p is $offset")
+                kafkaConsumer.seek(p, offset)
+            }
+
             var msgCount = 0
             while (msgCount < maxMsgCount) {
-                partitions.forEach { partition ->
+                val msgs = partitions.map { partition ->
                     kafkaConsumer
                         .poll(Duration.ofMillis(100)).records(partition)
-                        .forEach { record ->
+                        .map { record ->
                             val key = String(record.key(), Charsets.UTF_8)
                             val value = String(record.value(), Charsets.UTF_8)
-                            val msg = Message(partition.toString(), key, value)
-                            yield(msg)
-                            msgCount += 1
+                            Message(record.offset(), partition.toString(), key, value)
                         }
-                }
+                }.flatten()
+
+                if (msgs.isEmpty())
+                    Thread.sleep(300)
+                else
+                    yieldAll(msgs.sortedBy { it.offset })
+
+                msgCount += msgs.count()
             }
             logger.debug("stopping to process")
         }

--- a/http/src/main/kotlin/kafkasnoop/routes/MessageProcessor.kt
+++ b/http/src/main/kotlin/kafkasnoop/routes/MessageProcessor.kt
@@ -1,64 +1,58 @@
 package kafkasnoop.routes
 
+import kafkasnoop.KafkaClientFactory
 import kafkasnoop.dto.Message
-import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.common.TopicPartition
 import java.time.Duration
 import kotlin.math.max
 
+/**
+ * Message processor
+ *
+ * NOTE: changed this to use 1 consumer per partition.
+ * According to the docs, reading assigning multiple partitions to a consumer without a cosnumer group should
+ * be fine, but it appeared unreliable. This probably means something was wrong in my code, but will come back to this.
+ */
 class MessageProcessor(
-    private val kafkaConsumer: KafkaConsumer<ByteArray, ByteArray>,
+    private val kafkaClientFactory: KafkaClientFactory,
     private val topicName: String,
     // todo: take offset from query string & filter partitions
     private val startOffset: Long? = null,
 ) {
-    private val partitions: List<TopicPartition>
+    val partitions: List<TopicPartition>
     init {
         logger.debug("Getting messages for $topicName")
-
-        partitions = kafkaConsumer.partitionsFor(topicName).map {
-            TopicPartition(it.topic(), it.partition())
+        kafkaClientFactory.createConsumer().use {
+            partitions = it.partitionsFor(topicName).map {
+                TopicPartition(it.topic(), it.partition())
+            }
         }
-        kafkaConsumer.assign(partitions)
     }
 
-    fun startProcess(maxMsgCount: Int = Int.MAX_VALUE) =
+    fun startProcess(partition: TopicPartition, maxMsgCount: Int = Int.MAX_VALUE) =
         sequence {
-            val beggingOffsets = kafkaConsumer.beginningOffsets(partitions)
-            val endOffsets = kafkaConsumer.endOffsets(partitions)
+            kafkaClientFactory.createConsumer().use { kafkaConsumer ->
+                kafkaConsumer.assign(listOf(partition))
+                val beggingOffsets = kafkaConsumer.beginningOffsets(partitions)
+                val endOffsets = kafkaConsumer.endOffsets(partitions)
 
-            if (logger.isDebugEnabled) {
-                beggingOffsets.forEach {
-                    logger.debug("Begin Offset for ${it.key} is ${it.value}")
-                }
-                endOffsets.forEach {
-                    logger.debug("End Offset for ${it.key} is ${it.value}")
-                }
-            }
+                // default to rewinding to 5 or max msg count
+                val offsetDiff = if (maxMsgCount == Int.MAX_VALUE) 5 else maxMsgCount
+                logger.info("Return messages from offset $startOffset")
+                logger.debug("Min offset for partition $partition is ${beggingOffsets[partition]}")
+                logger.debug("Max offset for partition $partition is ${endOffsets[partition]}")
+                val startOffset = max(endOffsets[partition]?.minus(offsetDiff) ?: 0L, 0L)
+                val offset = max(startOffset, beggingOffsets[partition] ?: 0)
+                val messageCount = endOffsets.getOrDefault(partition, 0) - offset
+                logger.info("Loading $messageCount from $partition starting at $offset")
+                kafkaConsumer.seek(partition, offset)
 
-            // default to rewinding to 5 or max msg count
-            val offsetDiff = if (maxMsgCount == Int.MAX_VALUE) 5 else maxMsgCount
-            logger.info("Return messasges from offset $startOffset")
-
-            val messageCounts = partitions.map { p ->
-                logger.debug("Min offset for partition $p is ${beggingOffsets[p]}")
-                logger.debug("Max offset for partition $p is ${endOffsets[p]}")
-                val startOffset = max(endOffsets[p]?.minus(offsetDiff) ?: 0L, 0L)
-                val offset = max(startOffset, beggingOffsets[p] ?: 0)
-                val numberOfMessages = endOffsets.getOrDefault(p, 0) - offset + 1
-                logger.info("Loading $numberOfMessages from $p starting at $offset")
-                kafkaConsumer.seek(p, offset)
-                p to numberOfMessages
-            }.toMap()
-
-            val messagesToLoad = max(maxMsgCount, messageCounts.map { it.value.toInt() }.sum())
-            var messagesLoaded = 0
-            var emptyPolls = 0
-            // TODO: work out why we sometimes never get all the messages.
-            while ((maxMsgCount == Int.MAX_VALUE || emptyPolls <= 5) && messagesLoaded < messagesToLoad) {
-                val msgs = partitions.map { partition ->
+                var messagesLoaded = 0
+                var emptyPolls = 0
+                // TODO: work out why we sometimes never get all the messages.
+                while ((maxMsgCount == Int.MAX_VALUE || emptyPolls <= 5) && messagesLoaded < messageCount) {
                     logger.debug("Polling $partition from ${kafkaConsumer.position(partition)}")
-                    kafkaConsumer
+                    val msgs = kafkaConsumer
                         .poll(Duration.ofMillis(200)).records(partition)
                         .map { record ->
                             logger.debug("Found message $partition: ${record.offset()}")
@@ -66,20 +60,20 @@ class MessageProcessor(
                             val value = String(record.value(), Charsets.UTF_8)
                             Message(record.offset(), partition.toString(), key, value, record.timestamp())
                         }
-                }.flatten()
 
-                if (msgs.isEmpty()) {
-                    emptyPolls += 1
-                    logger.debug("Empty polls: $emptyPolls")
-                    Thread.sleep(200)
-                } else {
-                    logger.debug("Found ${msgs.count()} on $topicName: ${msgs.groupBy { it.partition }.map { it.key to it.value.maxOf { it.offset } }.toMap()}")
-                    yieldAll(msgs.sortedBy { it.offset })
-                    emptyPolls = 0
+                    if (msgs.isEmpty()) {
+                        emptyPolls += 1
+                        logger.debug("Empty polls: $emptyPolls")
+                        Thread.sleep(200)
+                    } else {
+                        logger.debug("Found ${msgs.count()} on $topicName: ${msgs.groupBy { it.partition }.map { it.key to it.value.maxOf { it.offset } }.toMap()}")
+                        yieldAll(msgs.sortedBy { it.offset })
+                        emptyPolls = 0
+                    }
+                    messagesLoaded += msgs.count()
+                    logger.debug("Loaded $messagesLoaded out of $messageCount")
                 }
-                messagesLoaded += msgs.count()
-                logger.debug("Loaded $messagesLoaded out of $messagesToLoad")
+                logger.debug("stopping to process")
             }
-            logger.debug("stopping to process")
         }
 }

--- a/http/src/main/kotlin/kafkasnoop/routes/messages.kt
+++ b/http/src/main/kotlin/kafkasnoop/routes/messages.kt
@@ -6,29 +6,52 @@ import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.websocket.*
 import kafkasnoop.KafkaClientFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.ClosedReceiveChannelException
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.cancellable
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.launch
 
 fun Route.messages(kafkaClientFactory: KafkaClientFactory) {
 
     webSocket("/ws/{topic}") {
         call.run {
-            val topicName = call.parameters["topic"] ?: throw IllegalArgumentException("Topic must be provided")
 
+            val topicName = call.parameters["topic"] ?: throw IllegalArgumentException("Topic must be provided")
             // todo: take partition, limit and offset from query string
             val offset = 0L
 
-            val processor = MessageProcessor(kafkaClientFactory, topicName, offset)
-            val partitions = processor.partitions
+            MessageProcessor(kafkaClientFactory, topicName, offset).use { processor ->
+                val partitions = processor.partitions
 
-            // TODO: fix this up so that it streams from multiple partitions in parallel.
-            processor
-                .startProcess(partitions.first())
-                .forEach {
-                    logger.debug("Sending $it")
-                    send(
-                        Frame.Text(it.toString())
-                    )
+                // TODO: fix this up so that it exists properly when the WS disconnects.
+                val job = CoroutineScope(Dispatchers.Default).launch {
+                    partitions.map { p ->
+                        logger.info("Start processing from $p")
+                        processor.startProcess(p).asFlow()
+                    }.merge().cancellable().collect {
+                        logger.debug("Sending $it")
+                        send(
+                            Frame.Text(it.toString())
+                        )
+                    }
                 }
+                try {
+                    job.join()
+                } catch (e: ClosedReceiveChannelException) {
+                    logger.info("Websocket connecton closed")
+                    job.cancel()
+                } catch (e: Throwable) {
+                    logger.error(e.message)
+                    e.printStackTrace()
+                    job.cancel()
+                }
+            }
         }
+        logger.debug("Exit web socket")
     }
 
     get("/api/{topic}") {

--- a/http/src/main/kotlin/kafkasnoop/routes/messages.kt
+++ b/http/src/main/kotlin/kafkasnoop/routes/messages.kt
@@ -18,7 +18,9 @@ fun Route.messages(kafkaClientFactory: KafkaClientFactory) {
 
             kafkaClientFactory.createConsumer().use { consumer ->
                 MessageProcessor(consumer, topicName, offset)
-                    .startProcess().forEach {
+                    .startProcess()
+                    .forEach {
+                        logger.debug("Sending $it")
                         send(
                             Frame.Text(it.toString())
                         )

--- a/http/src/main/kotlin/kafkasnoop/routes/messages.kt
+++ b/http/src/main/kotlin/kafkasnoop/routes/messages.kt
@@ -34,7 +34,7 @@ fun Route.messages(kafkaClientFactory: KafkaClientFactory) {
             val topicName = call.parameters["topic"] ?: throw IllegalArgumentException("Topic must be provided")
 
             // todo: take partition, limit and offset from query string
-            val maxMsg = 100
+            val maxMsg = 10
             val offset = 0L
 
             kafkaClientFactory.createConsumer().use { consumer ->

--- a/http/src/main/kotlin/kafkasnoop/routes/messages.kt
+++ b/http/src/main/kotlin/kafkasnoop/routes/messages.kt
@@ -37,7 +37,7 @@ fun Route.messages(kafkaClientFactory: KafkaClientFactory) {
 
             kafkaClientFactory.createConsumer().use { consumer ->
                 val msgs = MessageProcessor(consumer, topicName, offset)
-                    .startProcess(maxMsg).toList()
+                    .startProcess(maxMsg).toList().sortedBy { it.offset }
                 respond(msgs)
             }
         }

--- a/http/src/main/kotlin/kafkasnoop/routes/topics.kt
+++ b/http/src/main/kotlin/kafkasnoop/routes/topics.kt
@@ -6,6 +6,7 @@ import io.ktor.routing.*
 import kafkasnoop.KafkaClientFactory
 import kafkasnoop.dto.Partition
 import kafkasnoop.dto.Topic
+import org.apache.kafka.common.TopicPartition
 
 fun Route.topics(kafkaClientFactory: KafkaClientFactory) {
     get("/api") {
@@ -15,11 +16,19 @@ fun Route.topics(kafkaClientFactory: KafkaClientFactory) {
                     .createConsumer().use {
                         it.listTopics()
                             .map { t ->
+                                val partitions = t.value.map { p -> TopicPartition(t.key, p.partition()) }
+                                val beggingOffsets = it.beginningOffsets(partitions)
+                                    .map { o -> o.key.partition() to o.value }.toMap()
+                                val endOffsets = it.endOffsets(partitions)
+                                    .map { o -> o.key.partition() to o.value }.toMap()
+
                                 Topic(
                                     t.key,
                                     t.value.map { p ->
                                         Partition(
                                             p.partition(),
+                                            beggingOffsets.getOrDefault(p.partition(), 0L),
+                                            endOffsets.getOrDefault(p.partition(), 0L),
                                             p.inSyncReplicas().count(),
                                             p.offlineReplicas().count()
                                         )

--- a/http/src/main/resources/logback.xml
+++ b/http/src/main/resources/logback.xml
@@ -1,0 +1,13 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.apache.kafka" level="INFO"/>
+
+    <root level="debug">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/http/src/main/resources/logback.xml
+++ b/http/src/main/resources/logback.xml
@@ -5,7 +5,7 @@
         </encoder>
     </appender>
 
-    <logger name="org.apache.kafka" level="INFO"/>
+    <logger name="org.apache.kafka" level="DEBUG"/>
 
     <root level="debug">
         <appender-ref ref="STDOUT" />

--- a/http/src/main/resources/logback.xml
+++ b/http/src/main/resources/logback.xml
@@ -5,7 +5,7 @@
         </encoder>
     </appender>
 
-    <logger name="org.apache.kafka" level="DEBUG"/>
+    <logger name="org.apache.kafka" level="INFO"/>
 
     <root level="debug">
         <appender-ref ref="STDOUT" />


### PR DESCRIPTION
Create a new consumer per partition.
This seems to be reliable as previously it seemed to dropped messages when there are more than 2 partitions.

Need to fix up the WS endpoint so it streams from the different consumers in parallel.